### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.0.0

### DIFF
--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <AssemblyName>DocumentationExamples</AssemblyName>
@@ -9,29 +8,24 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Shouldly\Shouldly.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="4.0.1" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0-beta1" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
NuKeeper has generated an update of `Microsoft.NET.Test.Sdk` to `15.0.0` from `15.0.0-preview-20170106-08`
1 project update:
Updated `src\DocumentationExamples\DocumentationExamples.csproj` to `Microsoft.NET.Test.Sdk` `15.0.0` from `15.0.0-preview-20170106-08`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
